### PR TITLE
Propose bashrc alias bootstrap flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ $ tilde contrib --list
     feels
     writo
     # truncated for example's sake
+$ tilde contrib --bootstrap
+    alias botany='tilde contrib botany'
+    alias feels='tilde contrib feels'
+    alias writo='tilde contrib writo'
+    # truncated for example's sake
+    # For backwards compatability when included in ~/.bashrc as `source $(tilde contrib --bootstrap)`
 $ tilde contrib botany
     # ...runs botany
 $ vim cool_program


### PR DESCRIPTION
This commit proposes a bootstrap flag that can be passed into the contrib subapplication for backwards compatibility if applications disappear from `/usr/bin/`. Backwards compatibility would persist for those that opt into the feature by adding `source $(tilde contrib --bootstrap)` to their ~/.bashrc or added globally with a modification to /etc/bash_profile. Additionally new features would be made available to everyone who uses this command to bootstrap their shell environment as soon as they are approved by a server admin.